### PR TITLE
Typo fix line 28 manor -> manner

### DIFF
--- a/_posts/en/workflow/0100-01-04-module3.md
+++ b/_posts/en/workflow/0100-01-04-module3.md
@@ -25,7 +25,7 @@ Please download the presentation <a href="/files/SAMPLE - OSM Mapathon - Student
 
 ### Student Training Video
 This particular video highlights a class project for Harare, Zimbabwe. Please feel free to use this video as a teaching aide.
-Please note, this video is using the HOT Tasking Manager, rather than they TeachOSM Tasking Manager, but they function in exactly the same manor. 
+Please note, this video is using the HOT Tasking Manager, rather than they TeachOSM Tasking Manager, but they function in exactly the same manner. 
 
 Student training Guide on YouTube
 


### PR DESCRIPTION
Changes noun manor (place to live) to noun manner (a way in which things are done).

edit: changed "verb" to "noun" as I guess manner is a noun as well, but it felt like a verb to me.
